### PR TITLE
Add OUTBOUND_ROUTE_NAME variable define

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -2250,6 +2250,7 @@ function core_get_config($engine) {
 													}
 													$ext->add($context, $exten, '', new ext_set("_NODEST",""));
 													$ext->add($context, $exten, '', new ext_gosub('1','s','sub-record-check','out,${EXTEN},'));
+													$ext->add($context, $exten, '', new ext_setvar('__OUTBOUND_ROUTE_NAME',$route['name']));
 
 													$password = $route['password'];
 													foreach ($trunks as $trunk_id) {


### PR DESCRIPTION
Added line that defines asterisk channel variable ${OUTBOUND_ROUTE_NAME} that is set to the FreePBX outbound route name in the GUI. Currently there is no indication in the Asterisk full log which outbound route the system uses, and this allows users to use the variable value elsewhere in dialplan, CDR etc.
