### PR TITLE
Urgent fix for macro-dialout-one-predial-hook

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -4241,7 +4241,7 @@ function core_do_get_config($engine) {
 
 		$mcontext = 'macro-dialout-one-predial-hook';
 		$exten = 's';
-		$ext->add($mcontext,$exten,'', new ext_return(''));
+		$ext->add($mcontext,$exten,'', new ext_macroexit(''));
 	}
 	break;
 }


### PR DESCRIPTION
MacroExit should be used in Macro instead of Return.