### PR TITLE
Release/13.0

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -1527,7 +1527,9 @@ function core_do_get_config($engine) {
 				}else{
 					$ext->add($context, $exten, '', new ext_setvar('__REVERSAL_REJECT','FALSE'));
 				}
-				$ext->add($context, $exten, '',new ext_gotoif('$["${__REVERSAL_REJECT}"="TRUE" & "${CHANNEL(reversecharge)}"="1" ]','macro-hangupcall'));
+				$ext->add($context, $exten, '', new ext_gotoif('$["${REVERSAL_REJECT}"="TRUE"]','post-reverse-charge'));
+				$ext->add($context, $exten, '', new ext_gotoif('$["${CHANNEL(reversecharge)}"="1"]','macro-hangupcall'));
+				$ext->add($context, $exten, 'post-reverse-charge', new ext_noop());
 
 				if ($item['delay_answer']) {
 					$ext->add($context, $exten, '', new ext_wait($item['delay_answer']));

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -1527,7 +1527,7 @@ function core_do_get_config($engine) {
 				}else{
 					$ext->add($context, $exten, '', new ext_setvar('__REVERSAL_REJECT','FALSE'));
 				}
-				$ext->add($context, $exten, '', new ext_gotoif('$["${REVERSAL_REJECT}"="TRUE"]','post-reverse-charge'));
+				$ext->add($context, $exten, '', new ext_gotoif('$["${REVERSAL_REJECT}"!="TRUE"]','post-reverse-charge'));
 				$ext->add($context, $exten, '', new ext_gotoif('$["${CHANNEL(reversecharge)}"="1"]','macro-hangupcall'));
 				$ext->add($context, $exten, 'post-reverse-charge', new ext_noop());
 


### PR DESCRIPTION
This is a fix for the "Unknown or unavailable item requested: 'reversecharge'" warning which some users with non ISDN/PRI trunks have been seeing.

Asterisk appears not to do lazy evaluation so using the "&" with a parameter which we don't want to get evaluated on the right does not work.

To fix this the test has been split on two lines.