### PR TITLE
Kludge around attempting to insert '' where an int is needed

### DIFF
--- a/Core.class.php
+++ b/Core.class.php
@@ -1258,7 +1258,7 @@ class Core extends \FreePBX_Helpers implements \BMO  {
 			$alertinfo = htmlspecialchars(isset($request['alertinfo'])?$request['alertinfo']:'');
 			$mohclass = isset($request['mohclass'])?$request['mohclass']:'default';
 			$grppre = isset($request['grppre'])?$request['grppre']:'';
-			$delay_answer = isset($request['delay_answer'])&&$request['delay_answer']?$request['delay_answer']:'';
+			$delay_answer = isset($request['delay_answer'])&&$request['delay_answer']?$request['delay_answer']:'0';
 			$pricid = isset($request['pricid'])?$request['pricid']:'';
 			$rnavsort = isset($request['rnavsort'])?$request['rnavsort']:'description';
 			$didfilter = isset($request['didfilter'])?$request['didfilter']:'';
@@ -1921,6 +1921,10 @@ class Core extends \FreePBX_Helpers implements \BMO  {
 		$settings['extension'] = trim(str_replace($invalidDIDChars, "", $settings['extension']));
 		$settings['cidnum'] = trim(str_replace($invalidDIDChars, "", $settings['cidnum']));
 
+		// XXX: Kludge for empty value
+		if ($settings['delay_answer'] == '') {
+			$settings['delay_answer'] = '0';
+		}
 		// Check to make sure the did is not being used elsewhere
 		//
 		$existing = $this->getDID($settings['extension'], $settings['cidnum']);

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -1266,12 +1266,12 @@ function core_do_get_config($engine) {
 		// Call pickup using app_pickup - Note that '**xtn' is hard-coded into the GXPs and SNOMs as a number to dial
 		// when a user pushes a flashing BLF.
 		//
-		// We need to add ringgoups to this so that if an extension is part of a ringgroup, we can try to pickup that
+		// We need to add ringgroups to this so that if an extension is part of a ringgroup, we can try to pickup that
 		// extension by trying the ringgoup which is what the pickup application is going to respond to.
 		//
 		// NOTICE: this may be confusing, we check if this is a BRI build of Asterisk and use dpickup instead of pickup
-		//         if it is. So we simply assign the varaible $ext_pickup which one it is, and use that variable when
-		//         creating all the extnesions below. So those are "$ext_pickup" on purpose!
+		//         if it is. So we simply assign the variable $ext_pickup which one it is, and use that variable when
+		//         creating all the extensions below. So those are "$ext_pickup" on purpose!
 		//
 		if ($fc_pickup != '' && $ast_ge_14) {
 			$ext->addInclude('from-internal-additional', 'app-pickup');
@@ -4018,7 +4018,7 @@ function core_do_get_config($engine) {
 	include 'functions.inc/macro-dial-one.php';
 	include 'functions.inc/func-sipheaders.php';
 	break;
-}
+	}
 }
 
 /* begin page.ampusers.php functions */


### PR DESCRIPTION
I'm not at all sure this is the "right" fix for this, it smells wrong.
However, it does allow the code to work, which it doesn't without
this fixup.

On my server, which has a fairly modern mysql, the database
will balk if one attempts to insert '' where it expects an integer.

When attempting to create a ringgroup, the delay_answer column doesn't
have a valid integer in it.  I had hoped that merely setting the default value
to zero (at line around 1561 in Core.class.php) would be enough to fix this
error, but it wasn't.

So I resorted to a more kludgy setting just before the value is used for running
the sql query (around line 1925).  This fix makes it work.

Without this fix, the UI will throw a php traceback during execution.
(Sorry, I don't have a screengrab of that failure.)

This might be related to having a newer mysql than the FreePBX distro uses,
similar to the issue with the 'cel' module that I reported earlier.
