### PR TITLE
Bugfix for dtmfmode allways being set to "auto"

### DIFF
--- a/functions.inc/drivers/PJSip.class.php
+++ b/functions.inc/drivers/PJSip.class.php
@@ -780,7 +780,7 @@ class PJSip extends \FreePBX\modules\Core\Drivers\Sip {
 		if(version_compare($this->version,'13','ge')) {
 			$validdtmf[] = "auto";
 		}
-		if (!in_array($trunk['dtmfmode'],$validdtmf)) {
+		if (!in_array($config['dtmfmode'],$validdtmf)) {
 			if(version_compare($this->version,'13','ge')) {
 				$config['dtmfmode'] = "auto";
 			} else {


### PR DESCRIPTION
I think this is a cut-and-paste error:
It should be `$config['dtmfmode']` instead of `$trunk['dtmfmode']`
This bug is currently setting `dtmf_mode=auto` as fallback, which prevents pjsip from authenticating extensions at all. (pjsip can not handle auto)

Bug was referenced here:
http://community.freepbx.org/t/fpbx12-and-asterisk13-sip-phones-wont-register-on-pjsip/25354/18
see xrobau's comment which says correctly, that "PJSip doesn't support dtmfmode=auto"