### PR TITLE
Add AMPBIN to the list of globals

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -1855,7 +1855,8 @@ function core_do_get_config($engine) {
 			"AMPDBUSER",
 			"AMPDBPASS",
 			"AMPDBFILE",
-
+			// for locating some helper scripts
+			"AMPBIN",
 			// Used to be globals migrated to freepbx_conf
 			"VMX_CONTEXT",
 			"VMX_PRI",


### PR DESCRIPTION
This is one of the two things I needed to do to address FREEPBX-13318.

Basically, just add AMPBIN to the list of globals that will be extracted at the top of the extensions_additional.conf file.
