### PR TITLE
Fix GROUP BY clause errors

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -608,7 +608,7 @@ class core_conf {
 			}
 		}
 
-		$sql = "SELECT tech.data,tech.id from $table_name as tech LEFT OUTER JOIN trunks on (tech.id = CONCAT('tr-peer-',trunks.trunkid) OR tech.id = CONCAT('tr-user-',trunks.trunkid)) where tech.keyword='account' and (trunks.disabled = 'off' OR trunks.disabled IS NULL) group by data";
+		$sql = "SELECT tech.data,tech.id from $table_name as tech LEFT OUTER JOIN trunks on (tech.id = CONCAT('tr-peer-',trunks.trunkid) OR tech.id = CONCAT('tr-user-',trunks.trunkid)) where tech.keyword='account' and (trunks.disabled = 'off' OR trunks.disabled IS NULL) group by data,id";
 		$results = $db->getAll($sql, DB_FETCHMODE_ASSOC);
 		if(DB::IsError($results)) {
 			die($results->getMessage());
@@ -753,7 +753,7 @@ class core_conf {
 			$additional .= $result['keyword']."=".$result['data']."\n";
 		}
 
-		$sql = "SELECT data,id from $table_name where keyword='account' and flags <> 1 group by data";
+		$sql = "SELECT data,id from $table_name where keyword='account' and flags <> 1 group by data,id";
 
 		$results = $db->getAll($sql, DB_FETCHMODE_ASSOC);
 		if(DB::IsError($results)) {

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -363,7 +363,7 @@ class core_conf {
 			}
 		}
 
-		$sql = "SELECT tech.data,tech.id from $table_name as tech LEFT OUTER JOIN trunks on (tech.id = CONCAT('tr-peer-',trunks.trunkid) OR tech.id = CONCAT('tr-user-',trunks.trunkid)) where tech.keyword='account' and (trunks.disabled = 'off' OR trunks.disabled IS NULL) group by data";
+		$sql = "SELECT tech.data,tech.id from $table_name as tech LEFT OUTER JOIN trunks on (tech.id = CONCAT('tr-peer-',trunks.trunkid) OR tech.id = CONCAT('tr-user-',trunks.trunkid)) where tech.keyword='account' and (trunks.disabled = 'off' OR trunks.disabled IS NULL) group by data,id";
 		$results = $db->getAll($sql, DB_FETCHMODE_ASSOC);
 		if(DB::IsError($results)) {
 			die($results->getMessage());


### PR DESCRIPTION
On default Ubuntu 16.04 install with MySQL  5.7, sip_additional.conf was not being populated.  Traced it to mysql having error like:
```
mysql> SELECT data,id from sip where keyword='account' and flags <> 1 group by data;
ERROR 1055 (42000): Expression #2 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'asterisk.sip.id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by
```