### PR TITLE
Update macro-user-callerid.php

### DIFF
--- a/functions.inc/macro-user-callerid.php
+++ b/functions.inc/macro-user-callerid.php
@@ -20,8 +20,9 @@ $ext->add($context, $exten, '', new ext_set('TOUCH_MONITOR','${UNIQUEID}'));
 // make sure AMPUSER is set if it doesn't get set below
 $ext->add($context, $exten, '', new ext_set('AMPUSER', '${IF($["${AMPUSER}" = ""]?${CALLERID(number)}:${AMPUSER})}'));
 $ext->add($context, $exten, '', new ext_gotoif('$["${CUT(CHANNEL,@,2):5:5}"="queue" | ${LEN(${AMPUSERCIDNAME})}]', 'report'));
-//REALCALLERIDNUM Inheriting because of: http://issues.freepbx.org/browse/FREEPBX-13173
-$ext->add($context, $exten, '', new ext_execif('$["${REALCALLERIDNUM:1:2}" = ""]', 'Set', '__REALCALLERIDNUM=${CALLERID(number)}'));
+//The Commit of http://issues.freepbx.org/browse/FREEPBX-13173 has broken the Call Transfer CID Feature when transfering a call from the Phone which initiated the call.
+//This is the new isse which should resolve this back and make Call Transfers working with correct CID. https://issues.freepbx.org/browse/FREEPBX-15550
+$ext->add($context, $exten, '', new ext_execif('$["${REALCALLERIDNUM:1:2}" = ""]', 'Set', 'REALCALLERIDNUM=${CALLERID(number)}'));
 $ext->add($context, $exten, '', new ext_set('AMPUSER', '${DB(DEVICE/${REALCALLERIDNUM}/user)}'));
 
 // Device & User: If they're not signed in, then they can't do anything.


### PR DESCRIPTION
The Commit of http://issues.freepbx.org/browse/FREEPBX-13173 has broken the Call Transfer CID Feature when transfering a call from the Phone which initiated the call.
This is the new isse which should resolve this back and make Call Transfers working with correct CID. https://issues.freepbx.org/browse/FREEPBX-15550