### PR TITLE
Added htmlspecialchars for register string

### DIFF
--- a/views/trunks/sip.php
+++ b/views/trunks/sip.php
@@ -152,7 +152,7 @@ if(!empty($trunk_usercontexts)){
 								<i class="fa fa-question-circle fpbx-help-icon" data-for="register"></i>
 							</div>
 							<div class="col-md-9">
-								<input type="text" class="form-control" name="register" id="register" value="<?php echo $register ?>" tabindex="<?php echo ++$tabindex;?>" />
+								<input type="text" class="form-control" name="register" id="register" value="<?php echo htmlspecialchars($register) ?>" tabindex="<?php echo ++$tabindex;?>" />
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
If register string in sip settings has additional quotes, all information after them is cut at the click of  "Submit" button.
For example +3322233@somedomain.by:somepass:"+3322233@somedomain.by"@9.9.9.9:5060
after submit shows like +3322233@somedomain.by:somepass: