### PR TITLE
Fix typo in trunk variables ignore list

### DIFF
--- a/functions.inc/drivers/PJSip.class.php
+++ b/functions.inc/drivers/PJSip.class.php
@@ -1477,7 +1477,7 @@ class PJSip extends \FreePBX\modules\Core\Drivers\Sip {
 			'tech',
 			'outcid',
 			'keepcid',
-			'maxhans',
+			'maxchans',
 			'failtrunk',
 			'dialoutprefix',
 			'channelid',


### PR DESCRIPTION
Did you mean maxchan?
when addTrunk function is called, an array of settings is merged with POST data (sigh)
variables in ignore list aren't written to pjsip database table. There is no maxchan variable in Asterisk configuration.