### PR TITLE
Fix a couple of PHP notices for unauthenticated trunks

### DIFF
--- a/functions.inc/drivers/PJSip.class.php
+++ b/functions.inc/drivers/PJSip.class.php
@@ -579,7 +579,7 @@ class PJSip extends \FreePBX\modules\Core\Drivers\Sip {
 			}
 
 			// Are we doing authentication?
-			if ($trunk['authentication'] !== "none") {
+			if ($trunk['authentication'] !== "none" && $trunk['authentication'] !== "off") {
 				$conf['pjsip.auth.conf'][$tn] = array(
 					'type' => 'auth',
 					'auth_type' => 'userpass',
@@ -607,7 +607,7 @@ class PJSip extends \FreePBX\modules\Core\Drivers\Sip {
 					$conf['pjsip.aor.conf'][$tn]['contact'] = $trunk['aor_contact'];
 				} else {
 					// If there is no username, don't add the @
-					if ($trunk['username']) {
+					if (!empty($trunk['username'])) {
 						if (!empty($trunk['sip_server_port'])) {
 							$conf['pjsip.aor.conf'][$tn]['contact'] = 'sip:'.$trunk['username'].'@'.$trunk['sip_server'].':'.$trunk['sip_server_port'];
 						} else {


### PR DESCRIPTION
The UI saves authentication in the database as "off" not "none." Left old value in just in case it's still used somewhere