### PR TITLE
Preserve Advanced Extension Settings in FreePBX GQL API

### DIFF
--- a/Api/Gql/Extensions.php
+++ b/Api/Gql/Extensions.php
@@ -106,11 +106,14 @@ class Extensions extends Base {
 								$userman = $this->freepbx->userman->getUserByUsername($input['extension']);
 								$input = $this->getUpdatedValues($extensionExists,$users,$userman,$input);
 
+                                $total = array_merge($users, $extensionExists);
+                                $total = array_merge($total, $input);
+
 								$this->freepbx->Core->delDevice($input['extension'], true);
 								$this->freepbx->Core->delUser($input['extension']);	
 								if(!empty($userman))
 							   	$this->freepbx->userman->deleteUserByID($userman['id']);
-								$status = $this->freepbx->Core->processQuickCreate($input['tech'] ,$input['extension'],$input);
+								$status = $this->freepbx->Core->processQuickCreate($input['tech'] ,$input['extension'],$total);
 								if($status == True){
 									return array("status" => true ,"message"=> _("Extension has been updated"));
 								}else{
@@ -450,6 +453,10 @@ class Extensions extends Base {
 				'type' => Type::string(),
 				'description' => _("Channel Name incase if you are using tech DAHDi.")
 			],
+            'ringtimer' => [
+                'type' => Type::string(),
+                'description' => _("Ring Time")
+            ],
 		];
 	}
 		
@@ -511,6 +518,10 @@ class Extensions extends Base {
 			 'maxContacts' => [
                 'type' => Type::string(),
                  'description' => _("Max Contacts will set the maximum concurrent contacts for a PJSIP extension")
+            ],
+            'ringtimer' => [
+                'type' => Type::string(),
+                'description' => _("Ring Time")
             ],
 		];
 	}
@@ -577,6 +588,10 @@ class Extensions extends Base {
           	'maxContacts' => [
                 'type' => Type::string(),
                 'description' => _("Max Contacts will set the maximum concurrent contacts for a PJSIP extension")
+            ],
+            'ringtimer' => [
+                'type' => Type::string(),
+                'description' => _("Ring Time")
             ],
 		];
 	}

--- a/Core.class.php
+++ b/Core.class.php
@@ -235,6 +235,53 @@ class Core extends FreePBX_Helpers implements BMO  {
 
 		$settings['emergency_cid']['value'] = isset($data['emergency_cid']) ? $data['emergency_cid'] : '';
 		$settings['callerid']['value'] = isset($data['callerid']) ? $data['callerid'] : '' ;
+
+        if($tech == "pjsip"){
+            $settings['dtmfmode']['value'] = isset($data['dtmfmode']) ? $data['dtmfmode'] : "rfc4733";
+            $settings['defaultuser']['value'] = isset($data['defaultuser']) ? $data['defaultuser'] : "";
+            $settings['trustrpid']['value'] = isset($data['trustrpid']) ? $data['trustrpid'] : "yes";
+            $settings['send_connected_line']['value'] = isset($data['send_connected_line']) ? $data['send_connected_line'] : "yes";
+            $settings['user_eq_phone']['value'] = isset($data['user_eq_phone']) ? $data['user_eq_phone'] : "no";
+            $settings['sendrpid']['value'] = isset($data['sendrpid']) ? $data['sendrpid'] : "pai";
+            $settings['qualifyfreq']['value'] = isset($data['qualifyfreq']) ? $data['qualifyfreq'] : 60;
+            $settings['transport']['value'] = isset($data['transport']) ? $data['transport'] : "";
+            $settings['avpf']['value'] = isset($data['avpf']) ? $data['avpf'] : "no";
+            $settings['icesupport']['value'] = isset($data['icesupport']) ? $data['icesupport'] : "no";
+            $settings['rtcp_mux']['value'] = isset($data['rtcp_mux']) ? $data['rtcp_mux'] : "no";
+            $settings['namedcallgroup']['value'] = isset($data['namedcallgroup']) ? $data['namedcallgroup'] : "";
+            $settings['namedpickupgroup']['value'] = isset($data['namedpickupgroup']) ? $data['namedpickupgroup'] : "";
+            $settings['disallow']['value'] = isset($data['disallow']) ? $data['disallow'] : "";
+            $settings['allow']['value'] = isset($data['allow']) ? $data['allow'] : "";
+            $settings['dial']['value'] = isset($data['dial']) ? $data['dial'] : "PJSIP/3";
+            $settings['mailbox']['value'] = isset($data['mailbox']) ? $data['mailbox'] : $extension."@device";
+            $settings['vmexten']['value'] = isset($data['vmexten']) ? $data['vmexten'] : "";
+            $settings['accountcode']['value'] = isset($data['accountcode']) ? $data['accountcode'] : "";
+            $settings['remove_existing']['value'] = isset($data['remove_existing']) ? $data['remove_existing'] : "no";
+            $settings['media_use_received_transport']['value'] = isset($data['media_use_received_transport']) ? $data['media_use_received_transport'] : "no";
+            $settings['rtp_symmetric']['value'] = isset($data['rtp_symmetric']) ? $data['rtp_symmetric'] : "yes";
+            $settings['rewrite_contact']['value'] = isset($data['rewrite_contact']) ? $data['rewrite_contact'] : "yes";
+            $settings['force_rport']['value'] = isset($data['force_rport']) ? $data['force_rport'] : "yes";
+            $settings['mwi_subscription']['value'] = isset($data['mwi_subscription']) ? $data['mwi_subscription'] : "auto";
+            $settings['aggregate_mwi']['value'] = isset($data['aggregate_mwi']) ? $data['aggregate_mwi'] : "no";
+            $settings['max_audio_streams']['value'] = isset($data['max_audio_streams']) ? $data['max_audio_streams'] : "1";
+            $settings['max_video_streams']['value'] = isset($data['max_video_streams']) ? $data['max_video_streams'] : "1";
+            $settings['media_encryption']['value'] = isset($data['media_encryption']) ? $data['media_encryption'] : "no";
+            $settings['timers']['value'] = isset($data['timers']) ? $data['timers'] : "yes";
+            $settings['timers_min_se']['value'] = isset($data['timers_min_se']) ? $data['timers_min_se'] : "90";
+            $settings['direct_media']['value'] = isset($data['direct_media']) ? $data['direct_media'] : "yes";
+            $settings['media_encryption_optimistic']['value'] = isset($data['media_encryption_optimistic']) ? $data['media_encryption_optimistic'] : "no";
+            $settings['refer_blind_progress']['value'] = isset($data['refer_blind_progress']) ? $data['refer_blind_progress'] : "yes";
+            $settings['device_state_busy_at']['value'] = isset($data['device_state_busy_at']) ? $data['device_state_busy_at'] : "0";
+            $settings['match']['value'] = isset($data['match']) ? $data['match'] : "";
+            $settings['maximum_expiration']['value'] = isset($data['maximum_expiration']) ? $data['maximum_expiration'] : "7200";
+            $settings['minimum_expiration']['value'] = isset($data['minimum_expiration']) ? $data['minimum_expiration'] : "60";
+            $settings['rtp_timeout']['value'] = isset($data['rtp_timeout']) ? $data['rtp_timeout'] : "0";
+            $settings['rtp_timeout_hold']['value'] = isset($data['rtp_timeout_hold']) ? $data['rtp_timeout_hold'] : "0";
+            $settings['outbound_proxy']['value'] = isset($data['outbound_proxy']) ? $data['outbound_proxy'] : '';
+            $settings['outbound_auth']['value'] = isset($data['outbound_auth']) ? $data['outbound_auth'] : "no";
+            $settings['message_context']['value'] = isset($data['message_context']) ? $data['message_context'] : "";
+        }
+
 		if(!$this->addDevice($extension,$tech,$settings)) {
 			return array("status" => false, "message" => _("Device was not added!"));
 		}
@@ -243,6 +290,35 @@ class Core extends FreePBX_Helpers implements BMO  {
 		if(isset($data['password']) && !empty($data['password'])){
 			$settings['password']  = $data['password'];
 		}
+
+        if($tech == "pjsip"){
+            $settings['sipname'] = isset($data['sipname']) ? $data['sipname'] : "";
+            $settings['cid_masquerade'] = isset($data['cid_masquerade']) ? $data['cid_masquerade'] : "";
+            $settings['dialopts'] = isset($data['dialopts']) ? $data['dialopts'] : "";
+            $settings['ringtimer'] = isset($data['ringtimer']) ? $data['ringtimer'] : 0;
+            $settings['rvolume'] = isset($data['rvolume']) ? $data['rvolume'] : "";
+            $settings['concurrency_limit'] = isset($data['concurrency_limit']) ? $data['concurrency_limit'] : "";
+            $settings['callwaiting'] = isset($data['callwaiting']) ? $data['callwaiting'] : 'enabled';
+            $settings['cwtone'] = isset($data['cwtone']) ? $data['cwtone'] : "disabled";
+            $settings['call_screen'] = isset($data['call_screen']) ? $data['call_screen'] : "0";
+            $settings['answermode'] = isset($data['answermode']) ? $data['answermode'] : "disabled";
+            $settings['intercom'] = isset($data['intercom']) ? $data['intercom'] : "enabled";
+            $settings['recording_in_external'] = isset($data['recording_in_external']) ? $data['recording_in_external'] : 'dontcare';
+            $settings['recording_out_external'] = isset($data['recording_out_external']) ? $data['recording_out_external'] : 'dontcare';
+            $settings['recording_in_internal'] = isset($data['recording_in_internal']) ? $data['recording_in_internal'] : 'dontcare';
+            $settings['recording_out_internal'] = isset($data['recording_out_internal']) ? $data['recording_out_internal'] : 'dontcare';
+            $settings['recording_ondemand'] = isset($data['recording_ondemand']) ? $data['recording_ondemand'] : 'disabled';
+            $settings['recording_priority'] = isset($data['recording_priority']) ? $data['recording_priority'] : "10";
+            $settings['noanswer_dest'] = isset($data['noanswer_dest']) ? $data['noanswer_dest'] : "";
+            $settings['noanswer_cid'] = isset($data['noanswer_cid']) ? $data['noanswer_cid'] : "";
+            $settings['busy_dest'] = isset($data['busy_dest']) ? $data['busy_dest'] : "";
+            $settings['busy_cid'] = isset($data['busy_cid']) ? $data['busy_cid'] : "";
+            $settings['chanunavail_dest'] = isset($data['chanunavail_dest']) ? $data['chanunavail_dest'] : "";
+            $settings['chanunavail_cid'] = isset($data['chanunavail_cid']) ? $data['chanunavail_cid'] : "";
+            $settings['outboundcid'] = isset($data['outboundcid']) ? $data['outboundcid'] : "";
+            $settings['pinless'] = isset($data['pinless']) ? $data['pinless'] : 'disabled';
+        }
+
 		try {
 			if(!$this->addUser($extension, $settings)) {
 				//cleanup
@@ -1480,6 +1556,9 @@ class Core extends FreePBX_Helpers implements BMO  {
 			"concurrency_limit" => "",
 			"chanunavail_dest" => "",
 			"accountcode" => "",
+            "dialopts" => "",
+            "call_screen" => "0",
+            "rvolume" => ""
 		);
 	}
 


### PR DESCRIPTION
### Issue
[bug]: Advanced Settings Reset or Omitted During Extension Creation/Modification via GQL API  
Original Issue: [https://github.com/FreePBX/issue-tracker/issues/528](https://github.com/FreePBX/issue-tracker/issues/528)  
**FreePBX Version**: 17.0.19.16  
**Asterisk Version**: 21.4.3

### Problem
When creating or modifying extensions via the FreePBX GQL API, advanced settings are often reset to default values or omitted entirely. This issue stems from the GQL API’s method of updating extensions: extensions are deleted and recreated without fully retaining user-specified parameters. Consequently, essential settings (e.g., DTMF Signaling, Transport, Call Waiting, Ring Time) revert to defaults, disrupting configurations that rely on specific, user-defined values.

### Solution
To resolve this issue, I enhanced the API’s handling of extension updates by merging all relevant data sources into a unified dataset before calling the update function. This modification ensures that all user-defined advanced settings are retained unless explicitly undefined, aligning the API’s behavior with expected user outcomes.

### Changes Made
1. **Modifications in Extensions.php**
   - Introduced a new variable `$total` to combine data from `$extensionsExists`, `$users`, and `$input`. This unified dataset includes the full scope of parameters needed to persist all advanced settings during updates.
   - Updated the call to `processQuickCreate()` to utilize `$total` instead of `$input`, ensuring complete parameter retention.

2. **Enhancements in Core.class.php**
   - Added conditional checks for each field provided by `generateDefaultUserSettings()` to ensure that `$settings` correctly reflects user-defined values:
     ```php
     $settings['ringtimer'] = isset($data['ringtimer']) ? $data['ringtimer'] : 0;
     ```
   - Applied the same conditional assignment approach to device settings, guaranteeing that user-specified values are prioritized. Example code:
     ```php
     $settings['trustrpid']['value'] = isset($data['trustrpid']) ? $data['trustrpid'] : "yes";
     ```

3. **Expanded Field Set in `getMutationFieldsupdate()`**
   - Adjusted `getMutationFieldsupdate()` to incorporate additional parameters where necessary. This ensures that essential fields are correctly recognized and updated during API calls. For example:
     ```php
     'ringtimer' => [
         'type' => Type::string(),
         'description' => _("Ring Time")
     ],
     ```

4. **Additions to Default Parameters in `generateDefaultUserSettings()`**
   - Extended `generateDefaultUserSettings()` to include new parameters, such as `dialopts`, `call_screen`, and `rvolume`, to ensure these fields can be managed and modified via the API. Code added:
     ```php
     public function generateDefaultUserSettings($number, $displayname) {
         return array(
             ...
             "call_screen" => "0",
             "rvolume" => "",
             "dialopts" => ""
         );
     }
     ```

Thank you for reviewing this merge request. Please let me know if further clarification or adjustments are required.