### PR TITLE
Default dashboard RSS feeds needed updating.

### DIFF
--- a/install.php
+++ b/install.php
@@ -1036,7 +1036,7 @@ unset($set);
 // This is here because conf type CONF_TYPE_TEXTAREA doesnt exist
 // if there is an upgrade from 2.11 to 12 until after framework is updated
 $set['category'] = 'System Setup';
-$set['value'] = "http://www.freepbx.org/rss.xml\nhttp://feeds.feedburner.com/InsideTheAsterisk";
+$set['value'] = "https://www.freepbx.org/rss.xml\nhttps://www.asterisk.org/blog/rss";
 $set['defaultval'] = $set['value'];
 $set['name'] = 'RSS Feeds';
 $set['description'] = 'RSS Feeds that are displayed in UCP and Dashboard. Separate each feed by a new line. Supported feeds are Atom 1.0 and RSS 0.91, 0.92, 1.0 and 2.0';


### PR DESCRIPTION
Update Asterisk RSS feed to point to current blog. Update FreePBX RSS feed to HTTPS instead of HTTP.

Resolves: [GitHub #569](https://github.com/FreePBX/issue-tracker/issues/569)