### PR TITLE
Preserve Voicemail Settings During FreePBX Extension Modifications via GQL API

### DIFF
--- a/Api/Gql/Extensions.php
+++ b/Api/Gql/Extensions.php
@@ -107,7 +107,7 @@ class Extensions extends Base {
 								$input = $this->getUpdatedValues($extensionExists,$users,$userman,$input);
 
 								$this->freepbx->Core->delDevice($input['extension'], true);
-								$this->freepbx->Core->delUser($input['extension']);	
+								$this->freepbx->Core->delUser($input['extension'], true);
 								if(!empty($userman))
 							   	$this->freepbx->userman->deleteUserByID($userman['id']);
 								$status = $this->freepbx->Core->processQuickCreate($input['tech'] ,$input['extension'],$input);

--- a/Core.class.php
+++ b/Core.class.php
@@ -2306,11 +2306,13 @@ class Core extends FreePBX_Helpers implements BMO  {
 			}
 
 			//voicemail symlink
-			$spooldir = $this->config->get('ASTSPOOLDIR');
-			$account = preg_replace("/\D/","",$account);
-			if(freepbx_trim ($account) !== "" && file_exists($spooldir."/voicemail/device/".$account)) {
-				exec("rm -f ".escapeshellarg($spooldir."/voicemail/device/".$account));
-			}
+            if (!$editmode) {
+                $spooldir = $this->config->get('ASTSPOOLDIR');
+                $account = preg_replace("/\D/", "", $account);
+                if (freepbx_trim($account) !== "" && file_exists($spooldir . "/voicemail/device/" . $account)) {
+                    exec("rm -f " . escapeshellarg($spooldir . "/voicemail/device/" . $account));
+                }
+            }
 		} else {
 			die_freepbx("Cannot connect to Asterisk Manager with ".$this->config->get("AMPMGRUSER")."/".$this->config->get("AMPMGRPASS"));
 		}


### PR DESCRIPTION
#### Issue
This pull request addresses Issue #581: Voicemail settings are deleted during extension modifications via the FreePBX API.

#### Problem
When updating extensions through the updateExtension GQL API endpoint, the voicemail folder is inadvertently deleted. This is due to the delDevice and delUser functions being called without conditions to prevent voicemail deletion during an edit operation. This behavior disrupts configurations by forcing administrators to manually recreate voicemail settings for extensions, adding unnecessary complexity and the risk of errors.

#### Solution
##### Modifications to `Core.class.php`
- Introduced a conditional check in the delDevice method using the $editmode parameter.
- If $editmode is set to false, the voicemail folder is deleted as part of the deletion process.
- If $editmode is true, the voicemail folder remains untouched during the update operation.

Updated Code:
```php
if (!$editmode) {
    $spooldir = $this->config->get('ASTSPOOLDIR');
    $account = preg_replace("/\D/", "", $account);
    if (freepbx_trim($account) !== "" && file_exists($spooldir . "/voicemail/device/" . $account)) {
        exec("rm -f " . escapeshellarg($spooldir . "/voicemail/device/" . $account));
    }
}
```
##### Changes in `updateExtension` Mutation (GQL API)
- Ensured that the $editmode parameter is set to true when calling the delUser function in the updateExtension mutation.
- This ensures that the voicemail folder is preserved during extension updates.

Updated Code:
```php
$this->freepbx->Core->delUser($input['extension'], true);
```

#### Changes Made

- In Core.class.php:
    - Modified the delDevice method to include a condition based on the $editmode parameter.
- In GQL/API/Extensions.php:
    - Updated the updateExtension endpoint to call delUser with $editmode explicitly set to true.

#### Testing
- Created an extension with voicemail settings.
- Updated the extension via the API using the updateExtension endpoint.
- Verified that voicemail folders and settings were retained after the update.
- Confirmed that the deletion behavior remained intact when extensions were explicitly deleted (e.g., when $editmode was false).

#### Conclusion
This pull request resolves the issue of voicemail deletion during API-based extension updates by introducing an edit mode parameter and ensuring its correct usage. The fix preserves voicemail settings, aligning with user expectations and improving the reliability of the FreePBX API.

Please let me know if further modifications or clarifications are needed. Thank you for reviewing this merge request!