### PR TITLE
Update PJSip.class.php - set send_connected_line to Yes

### DIFF
--- a/functions.inc/drivers/PJSip.class.php
+++ b/functions.inc/drivers/PJSip.class.php
@@ -96,7 +96,7 @@ class PJSip extends \FreePBX\modules\Core\Drivers\Sip {
 				"flag" => $flag++
 			),
 			"send_connected_line" => array(
-				"value" => "no",
+				"value" => "yes",
 				"flag" => $flag++
 			),
 			"user_eq_phone" => array(


### PR DESCRIPTION
Resolving issue #536 (https://github.com/FreePBX/issue-tracker/issues/536)
Set send_connected_line to Yes as Asterisk default value for this parameter. Fixing attended call transfer CallerID not being shown on transfer_to device.

Later this setting can be created as a default device setting for Advanced Configuration page.