### PR TITLE
FREEI-1637 With asterisk 18.20.2, MES graph is not displayed in cdrpro

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -2565,6 +2565,7 @@ function core_do_get_config($engine) {
 		$ext->add('trunk-dial-with-exten', '_[+-X].', '', new ext_return());
 		$ext->add('trunk-dial-with-exten', '_*X.','', new ext_dial('${OUT_${DIAL_TRUNK}}/${OUTNUM}${OUT_${DIAL_TRUNK}_SUFFIX}', '${TRUNK_RING_TIMER},${DIAL_TRUNK_OPTIONS}b(func-apply-sipheaders^s^1,(${DIAL_TRUNK}))'.$obroute_email));
                 $ext->add('trunk-dial-with-exten', '_*X.', '', new ext_return());
+		$ext->add('trunk-dial-with-exten', 'h', '', new ext_macro('hangupcall'));
 		/***********************************************************/
 	
 		$ext->add($context, $exten, '', new ext_noop('Dial failed for some reason with DIALSTATUS = ${DIALSTATUS} and HANGUPCAUSE = ${HANGUPCAUSE}'));


### PR DESCRIPTION
This PR will fix the Cdrpro MES Graph values that were not populating when we tried to make outbound calls.
