### PR TITLE
Outbound Routes: Uploaded csv-file is not recognized as valid csv

### DIFF
--- a/Core.class.php
+++ b/Core.class.php
@@ -1081,10 +1081,22 @@ class Core extends FreePBX_Helpers implements BMO  {
 			// Check if they uploaded a CSV file for their route patterns
 			//
 			if (isset($_FILES['pattern_file']) && $_FILES['pattern_file']['tmp_name'] != '') {
-				$mimes = array('text/csv');
-				if (!in_array($_FILES['pattern_file']['type'], $mimes)) {
-					echo "<script>javascript:alert('" . _("Unsupported Pattern file format") . "')</script>";
-					return;
+				 foreach($uploaded_file AS $line) {
+					if($first_line) {
+						if($line != 'prepend,prefix,"match pattern",callerid') {
+							echo "<script>javascript:alert('" . _("Unsupported Pattern file format") . "')</script>";
+							return;
+						}
+						else {
+							$first_line = false;
+						}
+					}
+					else {
+						if(!preg_match("/^[XZN0-9\+\.\-\[\]]*,[XZN0-9\+\.\-\[\]]*,[XZN0-9\+\.\-\[\]]*,[XZN0-9\+\.\-\[\]]*$/i", $line)) {
+							echo "<script>javascript:alert('" . _("Unsupported Pattern file format") . "')</script>";
+							return;
+						}
+					}
 				}
 				$fh = fopen($_FILES['pattern_file']['tmp_name'], 'r');
 				if ($fh !== false) {

--- a/Core.class.php
+++ b/Core.class.php
@@ -1081,7 +1081,9 @@ class Core extends FreePBX_Helpers implements BMO  {
 			// Check if they uploaded a CSV file for their route patterns
 			//
 			if (isset($_FILES['pattern_file']) && $_FILES['pattern_file']['tmp_name'] != '') {
-				 foreach($uploaded_file AS $line) {
+				$uploaded_file = file($_FILES['pattern_file']['tmp_name'], FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+				$first_line = true;
+				foreach($uploaded_file AS $line) {
 					if($first_line) {
 						if($line != 'prepend,prefix,"match pattern",callerid') {
 							echo "<script>javascript:alert('" . _("Unsupported Pattern file format") . "')</script>";


### PR DESCRIPTION
In special circumstances a uploaded csv-file with dial patterns is not recognized as valid, because some browsers send another mime-type. This PR removes the check if a csv-file was uploaded based on the mime type and adds a check if the uploaded file is in the correct format for FreePBX 17.

Bugfix FreePBX/issue-tracker#678