### PR TITLE
Update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ This is a module for [FreePBX©](http://www.freepbx.org/ "FreePBX Home Page"). [
 [FreePBX](http://www.freepbx.org/ "FreePBX Home Page") is a completely modular GUI for Asterisk written in PHP and Javascript. Meaning you can easily write any module you can think of and distribute it free of cost to your clients so that they can take advantage of beneficial features in [Asterisk](http://www.asterisk.org/ "Asterisk Home Page")
 
 ### Setting up a FreePBX system
-[See our WIKI](http://wiki.freepbx.org/display/FOP/Install+FreePBX)
+[See our WIKI](http://sangomakb.atlassian.net/wiki/spaces/FP/pages/9732130/Install+FreePBX)
 ### License
 [This modules code is licensed as GPLv3+](http://www.gnu.org/licenses/gpl-3.0.txt)
 ### Contributing
-To contribute code or modules back into the [FreePBX](http://www.freepbx.org/ "FreePBX Home Page") ecosystem you must fully read our Code License Agreement. We are not able to look at or accept patches or code of any kind until this document is filled out. Please take a look at [http://wiki.freepbx.org/display/DC/Code+License+Agreement](http://wiki.freepbx.org/display/DC/Code+License+Agreement) for more information
+To contribute code or modules back into the [FreePBX](http://www.freepbx.org/ "FreePBX Home Page") ecosystem you must fully read our Code License Agreement. We are not able to look at or accept patches or code of any kind until this document is filled out. Please take a look at [http://sangomakb.atlassian.net/wiki/spaces/FP/pages/10682663/Contributor+License+Agreement](http://sangomakb.atlassian.net/wiki/spaces/FP/pages/10682663/Contributor+License+Agreement) for more information
 ### Issues
-Please file bug reports at http://issues.freepbx.org
+Please file bug reports at http://github.com/FreePBX/issue-tracker/issues

--- a/module.xml
+++ b/module.xml
@@ -3,13 +3,14 @@
 	<repo>standard</repo>
 	<category>Applications</category>
 	<name>Core</name>
-	<version>17.0.18.18</version>
+	<version>17.0.18.19</version>
 	<publisher>Sangoma Technologies Corporation</publisher>
 	<license>GPLv3+</license>
 	<licenselink>http://www.gnu.org/licenses/gpl-3.0.txt</licenselink>
 	<candisable>no</candisable>
 	<canuninstall>no</canuninstall>
 	<changelog>
+		*17.0.18.19* #678 revert : Outbound Routes Dial patterns from CSV 
 		*17.0.18.18* #678 Outbound Routes Dial patterns from CSV 
 		*17.0.18.17* FREEI-1637 Adding missing Hangup Handling in certain contexts. 
 		*17.0.18.16* FREEI-1733 Follow me issue with external number + sign 


### PR DESCRIPTION
This PR updates the links to the old wiki (wiki.freepbx.org) to the new location (sangomakb.atlassian.net) and updates the settings 'more-info' in the module.xml file

Bugfix FreePBX/issue-tracker#700