### PR TITLE
Update Core.class.php removing hard coding of pjsip dial

### DIFF
--- a/Core.class.php
+++ b/Core.class.php
@@ -252,7 +252,7 @@ class Core extends FreePBX_Helpers implements BMO  {
             $settings['namedpickupgroup']['value'] = isset($data['namedpickupgroup']) ? $data['namedpickupgroup'] : "";
             $settings['disallow']['value'] = isset($data['disallow']) ? $data['disallow'] : "";
             $settings['allow']['value'] = isset($data['allow']) ? $data['allow'] : "";
-            $settings['dial']['value'] = isset($data['dial']) ? $data['dial'] : "PJSIP/3";
+            $settings['dial']['value'] = isset($data['dial']) ? $data['dial'] : "PJSIP/".$extension;
             $settings['mailbox']['value'] = isset($data['mailbox']) ? $data['mailbox'] : $extension."@device";
             $settings['vmexten']['value'] = isset($data['vmexten']) ? $data['vmexten'] : "";
             $settings['accountcode']['value'] = isset($data['accountcode']) ? $data['accountcode'] : "";


### PR DESCRIPTION
PJSIP's dial value was hardcoded to "PJSIP/3" for all extensions when $data('dial') was not set. An existing module we have that created extensions had a conflict after an update due to this. Other properties, such as 'mailbox' on the next line have a precedent for setting the default value with the new extension.