### PR TITLE
Allow toggling of the Asterisk /httpstatus page.

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -165,6 +165,7 @@ class core_conf {
 		$output = "[general]\n";
 		$output .= "enabled=".($freepbx_conf->get_conf_setting('HTTPENABLED') ? 'yes' : 'no')."\n";
 		$output .= "enablestatic=".($freepbx_conf->get_conf_setting('HTTPENABLESTATIC') ? 'yes' : 'no')."\n";
+		$output .= "enable_status=".($freepbx_conf->get_conf_setting('HTTPENABLESTATUS') ? 'yes' : 'no')."\n";
 		$output .= "bindaddr=".$freepbx_conf->get_conf_setting('HTTPBINDADDRESS')."\n";
 		$output .= "bindport=".$freepbx_conf->get_conf_setting('HTTPBINDPORT')."\n";
 		$output .= "prefix=".$freepbx_conf->get_conf_setting('HTTPPREFIX')."\n";

--- a/install.php
+++ b/install.php
@@ -743,6 +743,18 @@ $set['readonly'] = 0;
 $set['type'] = CONF_TYPE_BOOL;
 $freepbx_conf->define_conf_setting('HTTPENABLESTATIC',$set);
 
+// HTTPENABLESTATUS
+$set['value'] = false;
+$set['defaultval'] =& $set['value'];
+$set['options'] = '';
+$set['name'] = 'Enable Status Page';
+$set['description'] = 'Whether Asterisk should serve general status page at /httpstatus. Default is no.';
+$set['emptyok'] = 0;
+$set['level'] = 2;
+$set['readonly'] = 0;
+$set['type'] = CONF_TYPE_BOOL;
+$freepbx_conf->define_conf_setting('HTTPENABLESTATUS',$set);
+
 // HTTPBINDADDRESS
 $set['value'] = '127.0.0.1';
 $set['defaultval'] =& $set['value'];


### PR DESCRIPTION
Default in Asterisk is enabled whenever HTTP server is enabled. This was the previous behaviour in FreePBX.

The new default in FreePBX will be disabled /httpstatus. Users will need to manually enable if they need this URL.

Resolves: FreePBX/issue-tracker#926