### PR TITLE
fix: change extension input from number to text to preserve leading zeros

### DIFF
--- a/views/quickCreate.php
+++ b/views/quickCreate.php
@@ -53,7 +53,7 @@ foreach($drivers as $driver) {
 				<label class="control-label" for="extension"><?php echo _('Extension Number')?></label>
 				<i class="fa fa-question-circle fpbx-help-icon" data-for="extension"></i>
 			</div>
-			<div class="col-md-9"><input type="number" class="form-control" id="extension" name="extension" placeholder="<?php echo _('Enter Extension')?>" data-for="extension" value="<?php echo $startExt?>"></div>
+			<div class="col-md-9"><input type="text" pattern="[0-9]*" class="form-control" id="extension" name="extension" placeholder="<?php echo _('Enter Extension')?>" data-for="extension" value="<?php echo $startExt?>"></div>
 		</div>
 	</div>
 	<div class="row">


### PR DESCRIPTION
## Summary
- Fixes Quick Create extension input field to properly handle extensions with leading zeros
- Changes input type from 'number' to 'text' with pattern validation

## Problem
HTML `<input type="number">` strips leading zeros from values. For example, if a user enters "0123", the browser will display and submit "123". This is problematic for phone extensions that legitimately start with zero.

## Solution
Changed the extension input field to:
- `type="text"` - Preserves leading zeros as entered
- `pattern="[0-9]*"` - Ensures only numeric input is accepted
- Maintains all existing validation and functionality

## Changes
- Modified `/views/quickCreate.php` line 56
- Input type: `number` → `text`
- Added `pattern="[0-9]*"` attribute

## Testing
- Extensions with leading zeros (e.g., "0123") are now properly preserved
- Non-numeric input is rejected by the pattern attribute
- Existing validation still works correctly
- Applies to both FreePBX 16 and 17

Fixes #123