### PR TITLE
fix: sanitize extdisplay parameter to prevent XSS

### DIFF
--- a/views/devices.php
+++ b/views/devices.php
@@ -1,5 +1,5 @@
 <div class="display no-border">
-  <form class="popover-form fpbx-submit" name="frm_devices" action="config.php?display=devices<?php echo isset($_REQUEST['extdisplay']) && trim($_REQUEST['extdisplay']) != '' ? '&amp;extdisplay='.$_REQUEST['extdisplay'] : '' ?>" method="post" data-fpbx-delete="config.php?display=devices&amp;extdisplay=<?php echo $_REQUEST['extdisplay'] ?>&amp;action=del" role="form">
+  <form class="popover-form fpbx-submit" name="frm_devices" action="config.php?display=devices<?php echo isset($_REQUEST['extdisplay']) && trim($_REQUEST['extdisplay']) != '' ? '&amp;extdisplay='.htmlspecialchars($_REQUEST['extdisplay'], ENT_QUOTES, 'UTF-8') : '' ?>" method="post" data-fpbx-delete="config.php?display=devices&amp;extdisplay=<?php echo htmlspecialchars($_REQUEST['extdisplay'], ENT_QUOTES, 'UTF-8') ?>&amp;action=del" role="form">
     <?php foreach ( $html['top'] as $elem ) {
       echo $elem['html'];
     } ?>

--- a/views/extensions.php
+++ b/views/extensions.php
@@ -1,5 +1,5 @@
 <div class="display no-border">
-  <form class="popover-form fpbx-submit" id="frm_extensions" onsubmit="return frm_extensions_onsubmit(this);" name="frm_extensions" action="config.php?display=extensions<?php echo isset($_REQUEST['extdisplay']) && freepbx_trim ($_REQUEST['extdisplay']) != '' ? '&amp;extdisplay='.$_REQUEST['extdisplay'] : '' ?>" method="post" data-fpbx-delete="config.php?display=extensions&amp;extdisplay=<?php echo $_REQUEST['extdisplay'] ?>&amp;action=del" role="form">
+  <form class="popover-form fpbx-submit" id="frm_extensions" onsubmit="return frm_extensions_onsubmit(this);" name="frm_extensions" action="config.php?display=extensions<?php echo isset($_REQUEST['extdisplay']) && freepbx_trim ($_REQUEST['extdisplay']) != '' ? '&amp;extdisplay='.htmlspecialchars($_REQUEST['extdisplay'], ENT_QUOTES, 'UTF-8') : '' ?>" method="post" data-fpbx-delete="config.php?display=extensions&amp;extdisplay=<?php echo htmlspecialchars($_REQUEST['extdisplay'], ENT_QUOTES, 'UTF-8') ?>&amp;action=del" role="form">
     <?php foreach ( $html['top'] as $elem ) {
       echo $elem['html'];
     } ?>

--- a/views/users.php
+++ b/views/users.php
@@ -1,5 +1,5 @@
 <div class="fpbx-container">
-  <form class="popover-form fpbx-submit" name="frm_users" action="config.php?display=users<?php echo isset($_REQUEST['extdisplay']) && trim($_REQUEST['extdisplay']) != '' ? '&amp;extdisplay='.$_REQUEST['extdisplay'] : '' ?>" method="post" data-fpbx-delete="config.php?display=users&amp;extdisplay=<?php echo $_REQUEST['extdisplay'] ?>&amp;action=del" role="form">
+  <form class="popover-form fpbx-submit" name="frm_users" action="config.php?display=users<?php echo isset($_REQUEST['extdisplay']) && trim($_REQUEST['extdisplay']) != '' ? '&amp;extdisplay='.htmlspecialchars($_REQUEST['extdisplay'], ENT_QUOTES, 'UTF-8') : '' ?>" method="post" data-fpbx-delete="config.php?display=users&amp;extdisplay=<?php echo htmlspecialchars($_REQUEST['extdisplay'], ENT_QUOTES, 'UTF-8') ?>&amp;action=del" role="form">
     <?php foreach ( $html['top'] as $elem ) {
       echo $elem['html'];
     } ?>


### PR DESCRIPTION
fixes #176 — adds htmlspecialchars encoding to prevent xss in form attributes.

the extdisplay parameter was being output directly into the data-fpbx-delete attribute without sanitization across three views. an attacker could craft a url with embedded javascript that would execute in an admin's session.

changed all instances to use htmlspecialchars with ENT_QUOTES to properly escape any html/js payloads in the parameter.

tested that the forms still function correctly with normal input and that malicious payloads are now properly escaped in the rendered html.
