### PR TITLE
Fix: Auto-add dtls_auto_generate_cert for DTLS media_encryption endpoints

### DIFF
--- a/functions.inc/drivers/PJSip.class.php
+++ b/functions.inc/drivers/PJSip.class.php
@@ -1325,6 +1325,10 @@ class PJSip extends \FreePBX\modules\Core\Drivers\Sip {
 
 		if (!empty($config['media_encryption'])) {
 			$endpoint[] = "media_encryption=".$config['media_encryption'];
+			if ($config['media_encryption'] === 'dtls') {
+				$endpoint[] = "dtls_auto_generate_cert=yes";
+				$endpoint[] = "dtls_setup=actpass";
+			}
 		}
 
 		if (!empty($config['timers'])) {


### PR DESCRIPTION
When a PJSIP endpoint is configured with `media_encryption=dtls` (required for WebRTC), Asterisk needs `dtls_auto_generate_cert=yes` and `dtls_setup=actpass` to successfully negotiate DTLS-SRTP. Without these lines, WebRTC calls fail with "Couldn't negotiate stream" errors.

This patch automatically appends the required DTLS parameters whenever `media_encryption` is set to `dtls`, ensuring WebRTC extensions work out of the box without manual `custom_post.conf` entries.

**Changes:**
- `functions.inc/drivers/PJSip.class.php`: add `dtls_auto_generate_cert=yes` and `dtls_setup=actpass` when `media_encryption === 'dtls'`
