### PR TITLE
Fix for issue 1041 Call Waiting Tone Missing

### DIFF
--- a/Dialplan/macroDial.php
+++ b/Dialplan/macroDial.php
@@ -70,7 +70,7 @@ class macroDial{
         // Mixed ringall: one Dial() shares headers; B-legs need per-leg P/S adjustment (inherits to all legs).
         $ext->add($c,$s,'', new \ext_execif('$["${IS_PPHONE_ANY}"="1"]', 'Set', '__RG_SHARED_RVOL=1'));
         $ext->add($c,$s,'', new \ext_macro('dial-ringall-predial-hook'));
-	$ext->add($c,$s,'', new \ext_execif('$["${DB(AMPUSER/${EXTTOCALL}/cwtone)}" = "enabled" & "${EXTENSION_STATE(${EXTTOCALL})}" = "INUSE"]', 'Set','CWRING=r(callwaiting)','Set','CWRING='));
+	$ext->add($c,$s,'', new \ext_execif('$["${DB(AMPUSER/${EXTTOCALL}/cwtone)}" = "enabled" & "${EXTENSION_STATE(${EXTTOCALL})}" =~ "^(RING|HOLD)?INUSE$" ]', 'Set','CWRING=r(callwaiting)','Set','CWRING='));
         // Ring groups and follow-me use macro-dial instead of macro-exten-vm, so sub-record-check was
         // never run per extension when inbound/ring-group recording was dontcare. Apply extension
         // recording policy before Dial(); use the first member for ringall (one Dial() to all).
@@ -119,7 +119,7 @@ class macroDial{
         $ext->add($c,$s,'', new \ext_gosub('1','s','sub-check-pseries','${EXTTOCALL}'));
         $ext->add($c,$s,'', new \ext_gosub('1','s','sub-set-rvol-headers','single'));
         $ext->add($c,$s,'', new \ext_macro('dial-hunt-predial-hook'));
-	$ext->add($c,$s,'', new \ext_execif('$["${DB(AMPUSER/${EXTTOCALL}/cwtone)}" = "enabled" & "${EXTENSION_STATE(${EXTTOCALL})}" = "INUSE"]', 'Set','CWRING=r(callwaiting)','Set','CWRING='));
+	$ext->add($c,$s,'', new \ext_execif('$["${DB(AMPUSER/${EXTTOCALL}/cwtone)}" = "enabled" & "${EXTENSION_STATE(${EXTTOCALL})}" =~ "^(RING|HOLD)?INUSE$" ]', 'Set','CWRING=r(callwaiting)','Set','CWRING='));
 	$ext->add($c,$s,'', new \ext_gosub(1,'s','sub-record-check','exten,${EXTTOCALL},dontcare'));
 	/*********************************************************/
 	$ext->add($c,$s,'', new \ext_execif('$["${FMFM}" = "TRUE"]','Set','RGFMDIAL=${EXTTOCALL}','Set','RGFMDIAL=${NODEST}'));

--- a/Dialplan/macroDialone.php
+++ b/Dialplan/macroDialone.php
@@ -107,7 +107,7 @@ class macroDialone{
 
 		//dont allow inbound callers to transfer around inside the system
 		$ext->add($mcontext,$exten,'', new \ext_execif('$["${DIRECTION}" = "INBOUND"]', 'Set', 'D_OPTIONS=${STRREPLACE(D_OPTIONS,T)}I'));
-		$ext->add($mcontext,$exten,'', new \ext_execif('$["${DB(AMPUSER/${DEXTEN}/cwtone)}" = "enabled" & "${EXTENSION_STATE(${DEXTEN}@ext-local)}" = "INUSE"]', 'Set','CWRING=r(callwaiting)','Set','CWRING='));
+		$ext->add($mcontext,$exten,'', new \ext_execif('$["${DB(AMPUSER/${DEXTEN}/cwtone)}" = "enabled" & "${EXTENSION_STATE(${DEXTEN}@ext-local)}" =~ "^(RING|HOLD)?INUSE$" ]', 'Set','CWRING=r(callwaiting)','Set','CWRING='));
 		$ext->add($mcontext,$exten,'dialapp', new \ext_noop(''));
 		$ext->add($mcontext,$exten,'', new \ext_execif('$["${FROMQ}" = "true"]', 'Set', 'D_OPTIONS=${STRREPLACE(D_OPTIONS,T)}'));
 		/* dail using different context */


### PR DESCRIPTION
See the issue here : https://github.com/FreePBX/issue-tracker/issues/1041

I'm using a regex : `^(RING|HOLD)?INUSE$` to test the EXTENSION_STATE instead of testing if it is equal to INUSE.

Tested with macro-dial-one but not macro-dial :

```
root@freepbx17-dev:/var/log/asterisk# tail -f /var/log/asterisk/full|grep -B1 CWRING
[2026-06-16 14:34:15.846] VERBOSE[3212392][C-00000019] pbx.c: Executing [s@macro-dial-one:60] NoOp("Local/102@from-queue-00000019;2", "debug cwtone enabled : enabled aaaaaa extension state : NOT_INUSE") in new stack
[2026-06-16 14:34:15.846] VERBOSE[3212392][C-00000019] pbx.c: Executing [s@macro-dial-one:61] ExecIf("Local/102@from-queue-00000019;2", "0?Set(CWRING=r(callwaiting)):Set(CWRING=)") in new stack
--
[2026-06-16 14:34:17.556] VERBOSE[3212415][C-0000001a] pbx.c: Executing [s@macro-dial-one:60] NoOp("Local/102@from-queue-0000001b;2", "debug cwtone enabled : enabled aaaaaa extension state : INUSE") in new stack
[2026-06-16 14:34:17.557] VERBOSE[3212415][C-0000001a] pbx.c: Executing [s@macro-dial-one:61] ExecIf("Local/102@from-queue-0000001b;2", "1?Set(CWRING=r(callwaiting)):Set(CWRING=)") in new stack
--
[2026-06-16 14:34:21.101] VERBOSE[3212436][C-0000001b] pbx.c: Executing [s@macro-dial-one:60] NoOp("PJSIP/38205-00000027", "debug cwtone enabled : enabled aaaaaa extension state : RINGINUSE") in new stack
[2026-06-16 14:34:21.102] VERBOSE[3212436][C-0000001b] pbx.c: Executing [s@macro-dial-one:61] ExecIf("PJSIP/38205-00000027", "1?Set(CWRING=r(callwaiting)):Set(CWRING=)") in new stack

```
